### PR TITLE
Added ignore flags for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,26 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 	add_flags_cxx("-D_XOPEN_SOURCE=600")
 endif()
 
+
+macro(set_exe_flags)
+	if (NOT MSVC)
+		if ("${CLANG_VERSION}" VERSION_GREATER 3.5)
+			include(CheckCXXCompilerFlag)
+			check_cxx_compiler_flag(-Wno-reserved-id-macro HAS_NO_RESERVED_ID_MACRO)
+			check_cxx_compiler_flag(-Wno-documentation-unknown-command HAS_NO_DOCUMENTATION_UNKNOWN)
+			if (HAS_NO_RESERVED_ID_MACRO)
+				# Use this flag to ignore error for a reserved macro problem in sqlite 3
+				add_flags_cxx("-Wno-reserved-id-macro")
+			endif()
+			if (HAS_NO_DOCUMENTATION_UNKNOWN)
+				# Ignore another problem in sqlite
+				add_flags_cxx("-Wno-documentation-unknown-command")
+			endif()
+		endif()
+	endif()
+endmacro()
+
+
 add_library(sqlite ${SOURCE})
 target_link_libraries(sqlite lua)
 


### PR DESCRIPTION
I moved the flags from cuberite's cmake list to this one. With this change I don't get anymore the error for `zero as null pointer`. No idea why...

Will modify the pull request at cuberite  to update sqlite and to remove this flags.